### PR TITLE
Named parameters, contextualized errors, edge case bug fixes

### DIFF
--- a/ols.js
+++ b/ols.js
@@ -111,7 +111,7 @@ function reg(Y, X1, parameters) {
         'obs': n,
         'params': k,
         'R2': R2,
-        'AdjR2': ((1 - R2)*(n - 1)) / (n - k),
+        'AdjR2': 1 - (((1 - R2)*(n - 1)) / (n - k)),
         'RMSE': RMSE,
         'Fstat': Fstat,
         'Fvalue': FishF(Fstat, k - 1, n - k),

--- a/ols.js
+++ b/ols.js
@@ -55,11 +55,13 @@ function reg(Y, X1, Robust, parameters) {
     if (diagonalSEInverse == null) { return "Could not calculate Tstat" }
     var Tstat = B.col(1).toDiagonalMatrix().x(SE.toDiagonalMatrix().inverse()).diagonal();
     var Ybar = Y.col(1).toDiagonalMatrix().trace() / n;
-    var R2 = 1 - ((E.transpose().x(E)).e(1, 1) / ((Y.map(function(d) {
+    var SST = ((Y.map(function(d) {
         return d - Ybar;
     })).transpose().x((Y.map(function(d) {
         return d - Ybar;
-    })))).e(1, 1));
+    })))).e(1, 1);
+    var R2 = 1 - ((E.transpose().x(E)).e(1, 1) / SST);
+    var Fstat = ((R2 * SST) / (n - k - 1)) / (RMSE * RMSE);
     var E2 = E.x(E.transpose());
     var Vhat = E2.diagonal().toDiagonalMatrix();
     var RVarCov = XtransXinv.x(X.transpose()).x(Vhat.transpose()).x(X).x(XtransXinv).map(function(d) {

--- a/ols.js
+++ b/ols.js
@@ -30,16 +30,57 @@ function StudT(t, n) {
     }
 }
 
-function reg(Y, X1, Robust, parameters) {
+function FishF(f, n1, n2) {
+    var x = n2 / (n1 * f + n2)
+    if ((n1 % 2) == 0) {
+        return StatCom(1 - x, n2, n1 + n2 - 4, n2 - 2) * Math.pow(x, n2 / 2)
+    }
+    if ((n2 % 2) == 0) {
+        return 1 - StatCom(x, n1, n1 + n2 - 4, n1 - 2) * Math.pow(1 - x, n1 / 2)
+    }
+    var th = Math.atan(Math.sqrt(n1 * f / n2));
+    var a = th / PiD2;
+    var sth = Math.sin(th);
+    var cth = Math.cos(th)
+    if (n2 > 1) {
+        a = a + sth * cth * StatCom(cth * cth, 2, n2 - 3, -1) / PiD2
+    }
+    if (n1 == 1) {
+        return 1 - a
+    }
+    var c = 4 * StatCom(sth * sth, n2 + 1, n1 + n2 - 4, n2 - 2) * sth * Math.pow(cth, n2) / Pi
+    if (n2 == 1) {
+        return 1 - a + c / 2
+    }
+    var k = 2;
+    while (k <= (n2 - 1) / 2) {
+        c = c * k / (k - .5);
+        k = k + 1
+    }
+    return 1 - a + c
+}
+
+function StatCom(q, i, j, b) {
+    var zz = 1;
+    var z = zz;
+    var k = i;
+    while (k <= j) {
+        zz = zz * q * k / (k - b);
+        z = z + zz;
+        k = k + 2
+    }
+    return z
+}
+
+function reg(Y, X1, parameters) {
     var startTime = new Date().getTime();
-    if (Robust === undefined) Robust = false;
     var Ones = sylvester.Matrix.Ones(X1.rows(), 1);
     var X = Ones.augment(X1);
     var n = X.rows();
     var k = X.cols();
     var XtransXinv = (X.transpose().x(X)).inverse();
     if (XtransXinv === null) return "Collinearity error";
-    if (n - k <= 0) return "Too few degrees of freedom for estimating unknowns (" + k + " columns but only " + n + " rows)";
+    if (n - k <= 0) return "Too few degrees of freedom for estimating unknowns (" + k + " variables but only " + n + " observations)";
     var B = XtransXinv.x((X.transpose().x(Y)));
     var Yhat = X.x(B);
     var E = Y.subtract(Yhat);
@@ -52,7 +93,9 @@ function reg(Y, X1, Robust, parameters) {
         return Math.sqrt(d);
     });
     var diagonalSEInverse = SE.toDiagonalMatrix().inverse();
-    if (diagonalSEInverse == null) { return "Could not calculate Tstat" }
+    if (diagonalSEInverse == null) {
+        return "Could not calculate Tstat"
+    }
     var Tstat = B.col(1).toDiagonalMatrix().x(SE.toDiagonalMatrix().inverse()).diagonal();
     var Ybar = Y.col(1).toDiagonalMatrix().trace() / n;
     var SST = ((Y.map(function(d) {
@@ -62,17 +105,7 @@ function reg(Y, X1, Robust, parameters) {
     })))).e(1, 1);
     var R2 = 1 - ((E.transpose().x(E)).e(1, 1) / SST);
     var Fstat = ((R2 * SST) / (k - 1)) / S2;
-    var E2 = E.x(E.transpose());
-    var Vhat = E2.diagonal().toDiagonalMatrix();
-    var RVarCov = XtransXinv.x(X.transpose()).x(Vhat.transpose()).x(X).x(XtransXinv).map(function(d) {
-        return d * (n / (n - k));
-    });
-    var RSE = RVarCov.diagonal().map(function(d) {
-        return Math.sqrt(d);
-    });
-    var RSEdiagonalInverse = RSE.toDiagonalMatrix().inverse();
-    if (RSEdiagonalInverse == null) { return "Could not calculate RTstat" }
-    var RTstat = B.col(1).toDiagonalMatrix().x(RSEdiagonalInverse).diagonal();
+
     var result = {};
     result.overall = {
         'obs': n,
@@ -80,28 +113,18 @@ function reg(Y, X1, Robust, parameters) {
         'R2': R2,
         'RMSE': RMSE,
         'Fstat': Fstat,
-        'Robust': Robust,
+        'Fvalue': FishF(Fstat, k - 1, n - k),
         'Time': ((new Date().getTime()) - startTime) / 1000
     };
     var i = 0;
     for (i = 0; i < k; i++) {
         var name = (parameters && i !== 0) ? parameters[i - 1] : 'B' + i;
-
-        if (Robust === false) {
-            result[name] = {
-                'value': B.e(i + 1, 1),
-                'SE': SE.e(i + 1, 1),
-                'Tstat': Tstat.e(i + 1, 1),
-                'Pval': StudT(Tstat.e(i + 1, 1), n - k)
-            };
-        } else {
-            result[name] = {
-                'value': B.e(i + 1, 1),
-                'SE': RSE.e(i + 1, 1),
-                'Tstat': RTstat.e(i + 1, 1),
-                'Pval': StudT(RTstat.e(i + 1, 1), n - k)
-            };
-        }
+        result[name] = {
+            'value': B.e(i + 1, 1),
+            'SE': SE.e(i + 1, 1),
+            'Tstat': Tstat.e(i + 1, 1),
+            'Pval': StudT(Tstat.e(i + 1, 1), n - k)
+        };
     }
     return result;
 }

--- a/ols.js
+++ b/ols.js
@@ -111,6 +111,7 @@ function reg(Y, X1, parameters) {
         'obs': n,
         'params': k,
         'R2': R2,
+        'AdjR2': ((1 - R2)*(n - 1)) / (n - k),
         'RMSE': RMSE,
         'Fstat': Fstat,
         'Fvalue': FishF(Fstat, k - 1, n - k),

--- a/ols.js
+++ b/ols.js
@@ -61,7 +61,7 @@ function reg(Y, X1, Robust, parameters) {
         return d - Ybar;
     })))).e(1, 1);
     var R2 = 1 - ((E.transpose().x(E)).e(1, 1) / SST);
-    var Fstat = ((R2 * SST) / (n - k - 1)) / (RMSE * RMSE);
+    var Fstat = ((R2 * SST) / (k - 1)) / S2;
     var E2 = E.x(E.transpose());
     var Vhat = E2.diagonal().toDiagonalMatrix();
     var RVarCov = XtransXinv.x(X.transpose()).x(Vhat.transpose()).x(X).x(XtransXinv).map(function(d) {
@@ -79,6 +79,7 @@ function reg(Y, X1, Robust, parameters) {
         'params': k,
         'R2': R2,
         'RMSE': RMSE,
+        'Fstat': Fstat,
         'Robust': Robust,
         'Time': ((new Date().getTime()) - startTime) / 1000
     };

--- a/ols.js
+++ b/ols.js
@@ -1,52 +1,101 @@
 var sylvester = require('sylvester');
-var Pi=Math.PI,
-    PiD2=Pi/2;
-function StatCom(q,i,j,b) {
-    var zz=1; var z=zz; var k=i; while(k<=j) { zz=zz*q*k/(k-b); z=z+zz; k=k+2;}
+var Pi = Math.PI,
+    PiD2 = Pi / 2;
+
+function StatCom(q, i, j, b) {
+    var zz = 1;
+    var z = zz;
+    var k = i;
+    while (k <= j) {
+        zz = zz * q * k / (k - b);
+        z = z + zz;
+        k = k + 2;
+    }
     return z;
+}
+
+function StudT(t, n) {
+    t = Math.abs(t);
+    var w = t / Math.sqrt(n);
+    var th = Math.atan(w);
+    if (n == 1) {
+        return 1 - th / PiD2;
     }
-function StudT(t,n) {
-    t=Math.abs(t); var w=t/Math.sqrt(n); var th=Math.atan(w);
-    if(n==1) { return 1-th/PiD2;}
-    var sth=Math.sin(th); var cth=Math.cos(th);
-    if((n%2)==1)
-            { return 1-(th+sth*cth*StatCom(cth*cth,2,n-3,-1))/PiD2;}
-            else
-            { return 1-sth*StatCom(cth*cth,1,n-3,-1);}
+    var sth = Math.sin(th);
+    var cth = Math.cos(th);
+    if ((n % 2) == 1) {
+        return 1 - (th + sth * cth * StatCom(cth * cth, 2, n - 3, -1)) / PiD2;
+    } else {
+        return 1 - sth * StatCom(cth * cth, 1, n - 3, -1);
     }
+}
+
 function reg(Y, X1, Robust) {
     var startTime = new Date().getTime();
     if (Robust === undefined) Robust = false;
-    var Ones = sylvester.Matrix.Ones(X1.rows(),1);
+    var Ones = sylvester.Matrix.Ones(X1.rows(), 1);
     var X = Ones.augment(X1);
     var n = X.rows();
     var k = X.cols();
     var XtransXinv = (X.transpose().x(X)).inverse();
     if (XtransXinv === null) return "Collinearity error";
-    if (n-k<=0) return "Too few degrees of freedom for estimating unknowns (" + k + " columns but only " + n + " rows)";
-    var B = XtransXinv.x((X.transpose().x(Y))),
-        Yhat = X.x(B),
-        E = Y.subtract(Yhat),
-        S2 = (E.transpose().x(E)).x(1/(n-B.rows())).e(1,1),
-        RMSE = Math.sqrt(S2),
-        VarCov = XtransXinv.map(function(d){return d*S2;}),
-        SE = VarCov.diagonal().map(function(d){return Math.sqrt(d);}),
-        Tstat = B.col(1).toDiagonalMatrix().x(SE.toDiagonalMatrix().inverse()).diagonal(),
-        Ybar = Y.col(1).toDiagonalMatrix().trace()/n,
-        R2 = 1-((E.transpose().x(E)).e(1,1)/((Y.map(function(d){return d-Ybar;})).transpose().x((Y.map(function(d){return d-Ybar;})))).e(1,1)),
-        E2 = E.x(E.transpose()),
-        Vhat = E2.diagonal().toDiagonalMatrix(),
-        RVarCov = XtransXinv.x(X.transpose()).x(Vhat.transpose()).x(X).x(XtransXinv).map(function(d){return d*(n/(n-k));}),
-        RSE = RVarCov.diagonal().map(function(d){return Math.sqrt(d);}),
-        RTstat = B.col(1).toDiagonalMatrix().x(RSE.toDiagonalMatrix().inverse()).diagonal(),
-        result = {};
-        result.overall = {'obs':n,'params':k,'R2':R2,'RMSE':RMSE,'Robust':Robust,'Time':((new Date().getTime())-startTime)/1000};
+    if (n - k <= 0) return "Too few degrees of freedom for estimating unknowns (" + k + " columns but only " + n + " rows)";
+    var B = XtransXinv.x((X.transpose().x(Y)));
+    var Yhat = X.x(B);
+    var E = Y.subtract(Yhat);
+    var S2 = (E.transpose().x(E)).x(1 / (n - B.rows())).e(1, 1);
+    var RMSE = Math.sqrt(S2);
+    var VarCov = XtransXinv.map(function(d) {
+        return d * S2;
+    });
+    var SE = VarCov.diagonal().map(function(d) {
+        return Math.sqrt(d);
+    });
+    var diagonalSEInverse = SE.toDiagonalMatrix().inverse();
+    if (diagonalSEInverse == null) { return '' }
+    var Tstat = B.col(1).toDiagonalMatrix().x(SE.toDiagonalMatrix().inverse()).diagonal();
+    var Ybar = Y.col(1).toDiagonalMatrix().trace() / n;
+    var R2 = 1 - ((E.transpose().x(E)).e(1, 1) / ((Y.map(function(d) {
+        return d - Ybar;
+    })).transpose().x((Y.map(function(d) {
+        return d - Ybar;
+    })))).e(1, 1));
+    var E2 = E.x(E.transpose());
+    var Vhat = E2.diagonal().toDiagonalMatrix();
+    var RVarCov = XtransXinv.x(X.transpose()).x(Vhat.transpose()).x(X).x(XtransXinv).map(function(d) {
+        return d * (n / (n - k));
+    });
+    var RSE = RVarCov.diagonal().map(function(d) {
+        return Math.sqrt(d);
+    });
+    var RSEdiagonalInverse = RSE.toDiagonalMatrix().inverse();
+    if (RSEdiagonalInverse == null) { return '' }
+    var RTstat = B.col(1).toDiagonalMatrix().x(RSEdiagonalInverse).diagonal();
+    var result = {};
+    result.overall = {
+        'obs': n,
+        'params': k,
+        'R2': R2,
+        'RMSE': RMSE,
+        'Robust': Robust,
+        'Time': ((new Date().getTime()) - startTime) / 1000
+    };
     var i = 0;
-    for(i=0;i<k;i++){
-        if (Robust === false){
-            result['B'+i] = {'value':B.e(i+1,1),'SE':SE.e(i+1,1),'Tstat':Tstat.e(i+1,1),'Pval':StudT(Tstat.e(i+1,1),n-k)};
+    for (i = 0; i < k; i++) {
+        if (Robust === false) {
+            result['B' + i] = {
+                'value': B.e(i + 1, 1),
+                'SE': SE.e(i + 1, 1),
+                'Tstat': Tstat.e(i + 1, 1),
+                'Pval': StudT(Tstat.e(i + 1, 1), n - k)
+            };
         } else {
-            result['B'+i] = {'value':B.e(i+1,1),'SE':RSE.e(i+1,1),'Tstat':RTstat.e(i+1,1),'Pval':StudT(RTstat.e(i+1,1),n-k)};
+            result['B' + i] = {
+                'value': B.e(i + 1, 1),
+                'SE': RSE.e(i + 1, 1),
+                'Tstat': RTstat.e(i + 1, 1),
+                'Pval': StudT(RTstat.e(i + 1, 1), n - k)
+            };
         }
     }
     return result;

--- a/ols.js
+++ b/ols.js
@@ -30,7 +30,7 @@ function StudT(t, n) {
     }
 }
 
-function reg(Y, X1, Robust) {
+function reg(Y, X1, Robust, parameters) {
     var startTime = new Date().getTime();
     if (Robust === undefined) Robust = false;
     var Ones = sylvester.Matrix.Ones(X1.rows(), 1);
@@ -82,15 +82,17 @@ function reg(Y, X1, Robust) {
     };
     var i = 0;
     for (i = 0; i < k; i++) {
+        var name = (parameters && i !== 0) ? parameters[i - 1] : 'B' + i;
+
         if (Robust === false) {
-            result['B' + i] = {
+            result[name] = {
                 'value': B.e(i + 1, 1),
                 'SE': SE.e(i + 1, 1),
                 'Tstat': Tstat.e(i + 1, 1),
                 'Pval': StudT(Tstat.e(i + 1, 1), n - k)
             };
         } else {
-            result['B' + i] = {
+            result[name] = {
                 'value': B.e(i + 1, 1),
                 'SE': RSE.e(i + 1, 1),
                 'Tstat': RTstat.e(i + 1, 1),

--- a/ols.js
+++ b/ols.js
@@ -80,7 +80,7 @@ function reg(Y, X1, parameters) {
     var k = X.cols();
     var XtransXinv = (X.transpose().x(X)).inverse();
     if (XtransXinv === null) return "Collinearity error";
-    if (n - k <= 0) return "Too few degrees of freedom for estimating unknowns (" + k + " variables but only " + n + " observations)";
+    if (k >= n) return "Too few degrees of freedom for estimating unknowns (" + k + " variables but only " + n + " observations)";
     var B = XtransXinv.x((X.transpose().x(Y)));
     var Yhat = X.x(B);
     var E = Y.subtract(Yhat);

--- a/ols.js
+++ b/ols.js
@@ -52,7 +52,7 @@ function reg(Y, X1, Robust) {
         return Math.sqrt(d);
     });
     var diagonalSEInverse = SE.toDiagonalMatrix().inverse();
-    if (diagonalSEInverse == null) { return '' }
+    if (diagonalSEInverse == null) { return "Could not calculate Tstat" }
     var Tstat = B.col(1).toDiagonalMatrix().x(SE.toDiagonalMatrix().inverse()).diagonal();
     var Ybar = Y.col(1).toDiagonalMatrix().trace() / n;
     var R2 = 1 - ((E.transpose().x(E)).e(1, 1) / ((Y.map(function(d) {
@@ -69,7 +69,7 @@ function reg(Y, X1, Robust) {
         return Math.sqrt(d);
     });
     var RSEdiagonalInverse = RSE.toDiagonalMatrix().inverse();
-    if (RSEdiagonalInverse == null) { return '' }
+    if (RSEdiagonalInverse == null) { return "Could not calculate RTstat" }
     var RTstat = B.col(1).toDiagonalMatrix().x(RSEdiagonalInverse).diagonal();
     var result = {};
     result.overall = {

--- a/ols.js
+++ b/ols.js
@@ -1,6 +1,7 @@
 var sylvester = require('sylvester');
-var Pi = Math.PI,
-    PiD2 = Pi / 2;
+const Pi = Math.PI;
+const PiD2 = Pi / 2;
+const highTThreshold = 1.96;
 
 function StatCom(q, i, j, b) {
     var zz = 1;
@@ -60,18 +61,6 @@ function FishF(f, n1, n2) {
     return 1 - a + c
 }
 
-function StatCom(q, i, j, b) {
-    var zz = 1;
-    var z = zz;
-    var k = i;
-    while (k <= j) {
-        zz = zz * q * k / (k - b);
-        z = z + zz;
-        k = k + 2
-    }
-    return z
-}
-
 function reg(Y, X1, parameters) {
     var startTime = new Date().getTime();
     var Ones = sylvester.Matrix.Ones(X1.rows(), 1);
@@ -101,8 +90,8 @@ function reg(Y, X1, parameters) {
     var SST = ((Y.map(function(d) {
         return d - Ybar;
     })).transpose().x((Y.map(function(d) {
-        return d - Ybar;
-    })))).e(1, 1);
+            return d - Ybar;
+        })))).e(1, 1);
     var R2 = 1 - ((E.transpose().x(E)).e(1, 1) / SST);
     var Fstat = ((R2 * SST) / (k - 1)) / S2;
     var AdjR2 = 1 - (((1 - R2)*(n - 1)) / (n - k));
@@ -115,10 +104,11 @@ function reg(Y, X1, parameters) {
         'RMSE': RMSE,
         'Fstat': Fstat,
         'Fvalue': FishF(Fstat, k - 1, n - k),
-        'Time': ((new Date().getTime()) - startTime) / 1000
+        'Time': ((new Date().getTime()) - startTime) / 1000,
+        'AvgT': (Tstat.chomp(1).map(function (d) {return Math.abs(d);})).sum() / (Tstat.cols() - 1),
+        'HighT': (Tstat.chomp(1).map(function (d) {return (Math.abs(d) > highTThreshold) ? 1 : 0})).sum()
     };
-    var i = 0;
-    for (i = 0; i < k; i++) {
+    for (var i = 0; i < k; i++) {
         var name = (parameters && i !== 0) ? parameters[i - 1] : 'B' + i;
         result[name] = {
             'value': B.e(i + 1, 1),

--- a/ols.js
+++ b/ols.js
@@ -17,13 +17,13 @@ function StudT(t,n) {
 function reg(Y, X1, Robust) {
     var startTime = new Date().getTime();
     if (Robust === undefined) Robust = false;
-    var Ones = sylvester.Matrix.Ones(X1.rows(),1),
-        X = Ones.augment(X1),
-        n = X.rows(),
-        k = X.cols(),
-        XtransXinv = (X.transpose().x(X)).inverse();
+    var Ones = sylvester.Matrix.Ones(X1.rows(),1);
+    var X = Ones.augment(X1);
+    var n = X.rows();
+    var k = X.cols();
+    var XtransXinv = (X.transpose().x(X)).inverse();
     if (XtransXinv === null) return "Collinearity error";
-    if (n-k<=0) return "Too few degrees of freedom for estimating unknowns";
+    if (n-k<=0) return "Too few degrees of freedom for estimating unknowns (" + k + " columns but only " + n + " rows)";
     var B = XtransXinv.x((X.transpose().x(Y))),
         Yhat = X.x(B),
         E = Y.subtract(Yhat),

--- a/ols.js
+++ b/ols.js
@@ -105,13 +105,13 @@ function reg(Y, X1, parameters) {
     })))).e(1, 1);
     var R2 = 1 - ((E.transpose().x(E)).e(1, 1) / SST);
     var Fstat = ((R2 * SST) / (k - 1)) / S2;
-
+    var AdjR2 = 1 - (((1 - R2)*(n - 1)) / (n - k));
     var result = {};
     result.overall = {
         'obs': n,
         'params': k,
         'R2': R2,
-        'AdjR2': 1 - (((1 - R2)*(n - 1)) / (n - k)),
+        'AdjR2': AdjR2 < 0 ? 0 : AdjR2,
         'RMSE': RMSE,
         'Fstat': Fstat,
         'Fvalue': FishF(Fstat, k - 1, n - k),

--- a/reghandtest.js
+++ b/reghandtest.js
@@ -1,0 +1,27 @@
+var sylvester = require('sylvester'),
+    ols = require('./ols.js');
+    
+function randomreg(n,k){
+    var Y = sylvester.Matrix.Random(n,1);
+    Y = Y.x(10);
+    Y = Y.round();
+    var X = sylvester.Matrix.Random(n,k);
+    X = X.x(10);
+    X = X.round();
+    console.log('Y: ' + Y.elements);
+    console.log('X: ' + JSON.stringify(X.transpose().elements));
+    var reg = ols.reg(Y,X,true);
+    return reg;
+}
+
+function staticreg() {
+    var Y = $M([10,4,3,5,9,3,3,2,6,7]);
+    var X = $M([[6,4,9,1,4,6,4,0,9,10],[1,4,2,5,7,3,2,9,6,1],[6,0,2,3,6,2,8,8,5,7],[2,6,8,10,1,2,8,2,6,1]]);
+    X = X.transpose();
+
+    var reg = ols.reg(Y, X);
+    return reg;
+}
+
+console.log('Random: ' + JSON.stringify(randomreg(10, 4), null, 2));
+// console.log('Known: ' + JSON.stringify(staticreg(), null, 2));


### PR DESCRIPTION
I've made some modifications to your OLS implementation and figured I'd pass them along. See my commit messages. Specifically, ebaddc4 gets rid of some crashes I was facing when dealing with null values and 0'd out rows, and in 61f370f I added the ability to use named parameters by passing an array of strings corresponding to parameter names.
